### PR TITLE
Add Workflow to upload to PyPi

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -1,0 +1,31 @@
+name: Upload to PyPi
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USER_scimma }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PW_scimma }}
+      run: |
+        python3 setup.py sdist bdist_wheel
+        python3 -m twine upload --repository-url https://pypi.org/ dist/* -u $TWINE_USERNAME -p $TWINE_PASSWORD


### PR DESCRIPTION
This PR creates a Github action workflow to bundle and upload the package to PyPi after a new version is pushed with Github tags.