### PR TITLE
Add example GCN circular

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE README.md MANIFEST.in
+recursive-include tests *.py *.gcn3

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Publish a GCN to Kafka:
 scimma publish -b kafka://hostname:port/gcn mygcn.gcn3
 ```
 
+An example RFC 822 formatted GCN circular (`example.gcn3`) is provided in
+`tests/data`.
+
 ## Installation
 
 You can install scimma-client either via pip, conda, or from source.

--- a/tests/data/example.gcn3
+++ b/tests/data/example.gcn3
@@ -1,0 +1,13 @@
+TITLE:   GCN CIRCULAR
+NUMBER:  26936
+SUBJECT: LIGO/Virgo S200129m: Not observable by Fermi-GBM
+DATE:    20/01/29 17:07:21 GMT
+FROM:    Adam Goldstein at Fermi-GBM, USRA  <adam.michael.goldstein@gmail.com>
+
+A. Goldstein (USRA) reports on behalf of the Fermi-GBM Team and the
+GBM-LIGO/Virgo group:
+
+For S200129m and using the bayestar.fits.gz,1 skymap, Fermi-GBM did not
+observe any of the localization probability at event time due to Earth
+occultation. Therefore, the GBM observations are not constraining for
+prompt gamma-ray emission.


### PR DESCRIPTION
This PR adds an example GCN circular, `example.gcn3` in `tests/data`, adds the relevant files to the manifest, and documents its use in the README.