### PR TITLE
auto-changelog version updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,14 @@ help :
 	@echo '  make test                  run unit tests'
 	@echo '  make lint                  run linter'
 	@echo '  make doc                   make documentation'
+	@echo '  make changelog             update changelog based on version'
 	@echo '  make dist                  make binary and source packages'
 	@echo '  make dist-check            verify binary and source packages'
 	@echo '  make upload                upload to PyPI'
 	@echo
+
+VERSION ?= $(shell python setup.py --version)
+REPO_URL = https://github.com/scimma/client_library
 
 .PHONY: test
 test :
@@ -25,6 +29,11 @@ lint :
 .PHONY: doc
 doc :
 	cd doc && make html
+
+.PHONY: changelog
+changelog :
+	sed -i 's@## \[Unreleased]@## \[Unreleased]\n\n## \[$(VERSION)] - $(shell date +'%Y-%m-%d')@' CHANGELOG.md
+	sed -i 's@.*\[Unreleased]:.*@\[Unreleased]: $(REPO_URL)/compare/v$(VERSION)...HEAD\n[$(VERSION)]: $(REPO_URL)/releases/tag/v$(VERSION)@' CHANGELOG.md
 
 .PHONY: dist
 dist :


### PR DESCRIPTION
This PR adds a target in the `Makefile`, `make changelog`, to update the version in there automatically based on the current version reported by the scimma client.

The way I intend for this tool to be used is as part of the release process, in which one would update the changelog based on the proposed version (e.g. `make changelog VERSION=0.0.4`), create a commit with something like "bump version to 0.0.4" and open up a PR to ensure all the relevant tests pass and get reviewed. After that is done, we can then create a tag on that commit and push the tags to start the release pipeline.

This process works if we update the changelog in the `[Unreleased]` section for any relevant changes as PRs get opened up (example in #39), which also has a nice paper trail associated with it.