### PR TITLE
feature/conda_upload-2

### DIFF
--- a/.github/workflows/upload_package.yml
+++ b/.github/workflows/upload_package.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         #create env vars that cannot be created above due to syntax
         VERSION=$(python setup.py --version)
-        LINE_STR='{% set version = "v'${VERSION}'" %}'
+        LINE_STR='{% set version = "'${VERSION}'" %}'
         SOURCE_URL="https://pypi.io/packages/source/s/${NAME}/${NAME}-${VERSION}.tar.gz"
 
         #prepend version environment variable before writing files (preserves version of master)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: {{ version }}
 
 source:
-  url: "https://pypi.io/packages/source/s/{{ name }}/{{ name}}-{{ version[1:] }}.tar.gz"
+  url: "https://pypi.io/packages/source/s/{{ name }}/{{ name }}-{{ version }}.tar.gz"
   sha256: "c0f87a158f6ea3cd302b13fec00b81445a6edf3e4629a8744078ad120f810f69"
 
 build:


### PR DESCRIPTION
This PR fixes the conda package uploading to the wrong URL (e.g., https://anaconda.org/SCiMMA/scimma-client/**v**0.0.4/).