### PR TITLE
Add `make format` to show any code change recommendations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ help :
 	@echo
 	@echo '  make test                  run unit tests'
 	@echo '  make lint                  run linter'
+	@echo '  make format                run code formatter, giving a diff for recommended changes'
 	@echo '  make doc                   make documentation'
 	@echo '  make changelog             update changelog based on version'
 	@echo '  make dist                  make binary and source packages'
@@ -25,6 +26,12 @@ lint :
 	flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 	# exit-zero treats all errors as warnings
 	flake8 . --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
+
+.PHONY: format
+format :
+	# show diff via black
+	black tests --diff
+	black scimma/client --diff
 
 .PHONY: doc
 doc :

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,11 @@
 [flake8]
 exclude =
     setup.py,
-	__pycache__,
-	.eggs/,
-	.git/,
-	build/,
-	doc/
+    scimma/client/_version.py,
+    __pycache__,
+    .eggs/,
+    .git/,
+    build/,
+    doc/
 per-file-ignores =
 	__init__.py:F401


### PR DESCRIPTION
## Description

See title. Also modify `setup.cfg` to ignore the version file when linting, plus tabs->spaces.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
