### PR TITLE
Expose a python-based client API

### DIFF
--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -6,4 +6,6 @@ scimma-client API
 .. toctree::
     :maxdepth: 2
 
+    io
     publish
+    models

--- a/doc/api/io.rst
+++ b/doc/api/io.rst
@@ -1,0 +1,7 @@
+.. _io:
+
+scimma.client.io
+################
+
+.. automodule:: scimma.client.io
+    :members:

--- a/doc/api/models.rst
+++ b/doc/api/models.rst
@@ -1,0 +1,7 @@
+.. _models:
+
+scimma.client.models
+#####################
+
+.. automodule:: scimma.client.models
+    :members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,6 +10,7 @@ User's Guide
    user/installation
    user/quickstart
    user/commands
+   user/stream
 
 API Reference
 -------------

--- a/doc/user/quickstart.rst
+++ b/doc/user/quickstart.rst
@@ -8,6 +8,8 @@ Quickstart
 Reading messages
 ----------------
 
+The scimma client supports a python-based API for reading messages from a stream, as follows:
+
 .. code:: python
 
     from scimma.client import stream
@@ -16,8 +18,21 @@ Reading messages
         for idx, msg in s:
              print(msg)
 
+This block will hang forever, listening to new messages and processing them as they arrive.
+By default, this will only process new messages since the connection was opened. The :code:`start_at`
+option lets you control where in the stream you can start listening from. For example,
+if you'd like to listen to all messages stored in a topic, you can do:
+
+.. code:: python
+
+    with stream.open("kafka://hostname:port/topic", "r", format="json", start_at="latest") as s:
+        for idx, msg in s:
+             print(msg)
+
 Writing messages
 ----------------
+
+We can also publish messages to a topic, as follows:
 
 .. code:: python
 

--- a/doc/user/quickstart.rst
+++ b/doc/user/quickstart.rst
@@ -13,7 +13,7 @@ Reading messages
     from scimma.client import stream
 
     with stream.open("kafka://hostname:port/topic", "r", format="json") as s:
-        for idx, msg in stream(timeout=10):
+        for idx, msg in s:
              print(msg)
 
 Writing messages

--- a/doc/user/quickstart.rst
+++ b/doc/user/quickstart.rst
@@ -5,7 +5,32 @@ Quickstart
 .. contents::
    :local:
 
-Publish a GCN to Kafka:
+Reading messages
+----------------
+
+.. code:: python
+
+    from scimma.client import stream
+
+    with stream.open("kafka://hostname:port/topic", "r", format="json") as s:
+        for idx, msg in stream(timeout=10):
+             print(msg)
+
+Writing messages
+----------------
+
+.. code:: python
+
+    from scimma.client import stream
+
+    with stream.open("kafka://hostname:port/topic", "w", format="json") as s:
+        s.write({"my": "message"})
+
+Using the CLI
+-------------
+
+Publish a GCN
+^^^^^^^^^^^^^
 
 .. code:: bash
 

--- a/doc/user/stream.rst
+++ b/doc/user/stream.rst
@@ -21,7 +21,7 @@ Let's open up a stream and show the Stream object in action:
 
     stream = Stream(format="json")
     with stream.open("kafka://hostname:port/topic", "r") as s:
-        for idx, msg in stream(timeout=10):
+        for idx, msg in s:
              print(msg)
 
 A common use case is to not specify any defaults, so a shorthand is
@@ -32,5 +32,14 @@ provided for using one:
     from scimma.client import stream
 
     with stream.open("kafka://hostname:port/topic", "r") as s:
-        for idx, msg in stream(timeout=10):
+        for _, msg in s:
+             print(msg)
+
+You can also configure the open stream handle with various options,
+including a timeout, a progress bar, and a message limit:
+
+.. code:: python
+
+    with stream.open("kafka://hostname:port/topic", "r") as s:
+        for _, msg in s(timeout=10, limit=20):
              print(msg)

--- a/doc/user/stream.rst
+++ b/doc/user/stream.rst
@@ -1,0 +1,36 @@
+==========
+Stream
+==========
+
+.. contents::
+   :local:
+
+The Stream Object
+-----------------
+
+The Stream object allows a user to connect to a Kafka broker and read
+in a variety of alerts, such as GCN circulars. It also allows one to
+specify default settings used across all streams opened from the Stream
+instance.
+
+Let's open up a stream and show the Stream object in action:
+
+.. code:: python
+
+    from scimma.client import Stream
+
+    stream = Stream(format="json")
+    with stream.open("kafka://hostname:port/topic", "r") as s:
+        for idx, msg in stream(timeout=10):
+             print(msg)
+
+A common use case is to not specify any defaults, so a shorthand is
+provided for using one:
+
+.. code:: python
+
+    from scimma.client import stream
+
+    with stream.open("kafka://hostname:port/topic", "r") as s:
+        for idx, msg in stream(timeout=10):
+             print(msg)

--- a/scimma/client/__init__.py
+++ b/scimma/client/__init__.py
@@ -2,3 +2,7 @@ try:
     from ._version import version as __version__
 except ImportError:
     pass
+
+from .io import Stream
+
+stream = Stream()

--- a/scimma/client/io.py
+++ b/scimma/client/io.py
@@ -32,6 +32,15 @@ class Stream(object):
     def open(self, *args, **kwargs):
         """Opens a connection to an event stream.
 
+        Args:
+          broker_url: sets the broker URL to connect to
+
+        Kwargs:
+          mode: read ('r') or write ('w') from the stream
+          format: the message serialization format
+          start_at: the message offset to start at
+          config: librdkafka style options, either a `dict` or a file path
+
         """
         opts = {**self._options, **kwargs}
         return streaming.open(*args, **kwargs)

--- a/scimma/client/io.py
+++ b/scimma/client/io.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
+__description__ = "a module for i/o utilities"
+
+
+from genesis import streaming
+
+
+class Stream(object):
+    """Defines an event stream.
+
+    Sets up defaults used within the genesis client, so that when a
+    stream connection is opened, it will use defaults specified here.
+
+    Args:
+      format: the message serialization format
+      start_at: the message offset to start at
+      config: librdkafka style options, either a `dict` or a file path
+
+    """
+
+    def __init__(self, format=None, start_at=None, config=None):
+        self._options = {}
+        if format is not None:
+            self._options["format"] = format
+        if start_at is not None:
+            self._options["start_at"] = start_at
+        if config is not None:
+            self._options["config"] = config
+
+    def open(self, *args, **kwargs):
+        """Opens a connection to an event stream.
+
+        """
+        opts = {**self._options, **kwargs}
+        return streaming.open(*args, **kwargs)

--- a/scimma/client/io.py
+++ b/scimma/client/io.py
@@ -43,4 +43,4 @@ class Stream(object):
 
         """
         opts = {**self._options, **kwargs}
-        return streaming.open(*args, **kwargs)
+        return streaming.open(*args, **opts)

--- a/scimma/client/models.py
+++ b/scimma/client/models.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
+__description__ = "a module to define common message types"
+
+
+from dataclasses import asdict, dataclass, field
+
+
+@dataclass
+class VOEvent(object):
+    """Defines a VOEvent 2.0 structure.
+
+    Implements the schema defined by:
+        http://www.ivoa.net/Documents/VOEvent/20110711/
+
+    """
+
+    ivorn: str
+    role: str = "observation"
+    version: str = "2.0"
+
+    Who: dict = field(default_factory=dict)
+    What: dict = field(default_factory=dict)
+    WhereWhen: dict = field(default_factory=dict)
+    How: dict = field(default_factory=dict)
+    Why: dict = field(default_factory=dict)
+    Citations: dict = field(default_factory=dict)
+    Description: dict = field(default_factory=dict)
+    Reference: dict = field(default_factory=dict)
+
+    def asdict(self):
+        """Represents the VOEvent as a dictionary.
+
+        Returns:
+            dict: the dict representation of the VOEvent.
+
+        """
+        return asdict(self)
+
+
+@dataclass
+class GCNCircular(object):
+    """Defines a GCN Circular structure.
+
+    """
+
+    header: dict
+    body: str
+
+    def asdict(self):
+        """Represents the GCN Circular as a dictionary.
+
+        Returns:
+            dict: the dict representation of the Circular.
+
+        """
+        return asdict(self)

--- a/scimma/client/publish.py
+++ b/scimma/client/publish.py
@@ -7,8 +7,7 @@ __description__ = "tools to parse and publish GCN circulars"
 import argparse
 import email
 
-from genesis import streaming as stream
-
+from .io import Stream
 from .models import GCNCircular
 
 
@@ -80,7 +79,8 @@ def _main(args=None):
     else:
         config = None
 
-    with stream.open(args.broker_url, "w", format="json", config=config) as s:
+    stream = Stream(format="json", config=config)
+    with stream.open(args.broker_url, "w") as s:
         for gcn_file in args.gcn:
             gcn = read_parse_gcn(gcn_file)
             s.write(gcn.asdict())

--- a/scimma/client/publish.py
+++ b/scimma/client/publish.py
@@ -9,6 +9,8 @@ import email
 
 from genesis import streaming as stream
 
+from .models import GCNCircular
+
 
 def read_parse_gcn(gcn_file):
     """Reads and parses a GCN circular file.
@@ -29,10 +31,10 @@ def read_parse_gcn(gcn_file):
         msg = email.message_from_file(f)
 
     # format gcn circular into header/body
-    return {
-        "header": {title.lower(): content for title, content in msg.items()},
-        "body": msg.get_payload(),
-    }
+    return GCNCircular(
+        header={title.lower(): content for title, content in msg.items()},
+        body=msg.get_payload(),
+    )
 
 
 # ------------------------------------------------
@@ -81,4 +83,4 @@ def _main(args=None):
     with stream.open(args.broker_url, "w", format="json", config=config) as s:
         for gcn_file in args.gcn:
             gcn = read_parse_gcn(gcn_file)
-            s.write(gcn)
+            s.write(gcn.asdict())

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,10 @@ with open(os.path.join(this_dir, 'README.md'), 'rb') as f:
     long_description = f.read().decode().strip()
 
 # requirements
-install_requires = ['adc>=0.0.2']
+install_requires = [
+    "adc >= 0.0.2",
+    "dataclasses ; python_version < '3.7'"
+]
 extras_require = {
     'dev': ['pytest', 'pytest-console-scripts', 'pytest-cov', 'flake8', 'flake8-black'],
     'docs': ['sphinx', 'sphinx_rtd_theme', 'sphinxcontrib-programoutput'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,3 +2,76 @@
 
 __author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
 __description__ = "global configuration for pytest suite"
+
+
+import pytest
+
+
+# example GCN circular from https://gcn.gsfc.nasa.gov/gcn3_circulars.html
+
+GCN_TITLE = "GCN GRB OBSERVATION REPORT"
+GCN_NUMBER = "40"
+GCN_SUBJECT = "GRB980329 VLA observations"
+GCN_DATE = "98/04/03 07:10:15 GMT"
+GCN_FROM = "Greg Taylor at NRAO"
+GCN_BODY = """
+G.B. Taylor, D.A. Frail (NRAO), S.R. Kulkarni (Caltech), and
+the BeppoSAX GRB team report:
+
+We have observed the field containing the proposed x-ray counterpart
+1SAX J0702.6+3850 of GRB 980329 (IAUC 6854) with the VLA at 8.4 GHz
+on UT 1998 Mar 30.2, April 1.1, and April 2.1.  Observations on April
+1.1 detected a radio source VLA J0702+3850 within the 1 arcminute
+error circle of 1SAX J0702.6+3850.  The coordinates of
+VLA J0702+3850 are: ra = 07h02m38.02170s dec = 38d50'44.0170" (equinox
+J2000) with an uncertainty of 0.05 arcsec in each coordinate.  The
+size of this radio source is less than 0.25 arcsec.  The density of
+sources on the sky stronger than 250 microJy at this frequency is
+0.0145 arcmin**-2.
+
+The flux density measurements of VLA J0702+3850 are as follows:
+
+Date(UT)   8.4 GHz Flux Density
+--------   ----------------------
+Mar 30.2   166 +/- 50 microJy
+Apr  1.1   248 +/- 16    "
+Apr  2.1    65 +/- 25    "
+
+where the uncertainty in the measurement reflects the 1 sigma rms
+noise in the image.  These measurements clearly demonstrate that
+the radio source is variable on timescales of less than 1 day.
+This rapid variability is similar to that observed in the
+radio afterglow from GRB 970508.  We propose VLA J0702+3850
+is the radio afterglow from GRB 980329.
+
+Additional radio observations are in progress.
+"""
+
+GCN_CIRCULAR = f"""\
+TITLE:   {GCN_TITLE}
+NUMBER:  {GCN_NUMBER}
+SUBJECT: {GCN_SUBJECT}
+DATE:    {GCN_DATE}
+FROM:    {GCN_FROM}
+
+{GCN_BODY}\
+"""
+
+
+@pytest.fixture(scope="session")
+def circular_text():
+    return GCN_CIRCULAR
+
+
+@pytest.fixture(scope="session")
+def circular_msg():
+    return {
+        "header": {
+            "title": GCN_TITLE,
+            "number": GCN_NUMBER,
+            "subject": GCN_SUBJECT,
+            "date": GCN_DATE,
+            "from": GCN_FROM,
+        },
+        "body": GCN_BODY,
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,8 +9,6 @@ import pytest
 
 from scimma.client import __version__
 
-from test_publish import GCN_CIRCULAR
-
 
 @pytest.mark.script_launch_mode("subprocess")
 def test_cli_scimma(script_runner):
@@ -24,13 +22,13 @@ def test_cli_scimma(script_runner):
     assert ret.stderr == ""
 
 
-def test_cli_publish(script_runner):
+def test_cli_publish(script_runner, circular_text):
     ret = script_runner.run("scimma", "publish", "--help")
     assert ret.success
 
-    gcn_mock = mock_open(read_data=GCN_CIRCULAR)
+    gcn_mock = mock_open(read_data=circular_text)
     with patch("scimma.client.publish.open", gcn_mock) as mock_file, patch(
-        "scimma.client.publish.stream.open", mock_open()
+        "scimma.client.io.Stream.open", mock_open()
     ) as mock_stream:
 
         gcn_file = "example.gcn3"
@@ -43,4 +41,4 @@ def test_cli_publish(script_runner):
 
         # verify GCN was processed
         mock_file.assert_called_with(gcn_file, "r")
-        mock_stream.assert_called_with(broker_url, "w", format="json", config=None)
+        mock_stream.assert_called_with(broker_url, "w")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -10,20 +10,23 @@ from scimma.client import Stream
 
 
 def test_stream(circular_msg, circular_text):
-    gcn_mock = mock_open(read_data=circular_text)
     with patch("scimma.client.io.streaming.open", mock_open()) as mock_stream:
         broker_url = "kafka://hostname:port/gcn"
         format = "json"
+        start_at = "beginning"
+        config = {}
 
-        stream = Stream(format="json", start_at="beginning", config={})
+        stream = Stream(format=format, start_at=start_at, config=config)
 
         # verify defaults are stored correctly
-        assert stream._options["format"] == "json"
-        assert stream._options["start_at"] == "beginning"
-        assert stream._options["config"] == {}
+        assert stream._options["format"] == format
+        assert stream._options["start_at"] == start_at
+        assert stream._options["config"] == config
 
         with stream.open(broker_url, "w") as s:
             s.write(circular_msg)
 
         # verify GCN was processed
-        mock_stream.assert_called_with(broker_url, "w")
+        mock_stream.assert_called_with(
+            broker_url, "w", format=format, start_at=start_at, config=config
+        )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
+__description__ = "a module that tests the io utilities"
+
+
+from unittest.mock import patch, mock_open
+
+from scimma.client import Stream
+
+
+def test_stream(circular_msg, circular_text):
+    gcn_mock = mock_open(read_data=circular_text)
+    with patch("scimma.client.io.streaming.open", mock_open()) as mock_stream:
+        broker_url = "kafka://hostname:port/gcn"
+        format = "json"
+
+        stream = Stream(format="json", start_at="beginning", config={})
+
+        # verify defaults are stored correctly
+        assert stream._options["format"] == "json"
+        assert stream._options["start_at"] == "beginning"
+        assert stream._options["config"] == {}
+
+        with stream.open(broker_url, "w") as s:
+            s.write(circular_msg)
+
+        # verify GCN was processed
+        mock_stream.assert_called_with(broker_url, "w")

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -9,71 +9,20 @@ from unittest.mock import patch, mock_open
 from scimma.client import publish
 
 
-# example GCN circular from https://gcn.gsfc.nasa.gov/gcn3_circulars.html
-
-GCN_TITLE = "GCN GRB OBSERVATION REPORT"
-GCN_NUMBER = "40"
-GCN_SUBJECT = "GRB980329 VLA observations"
-GCN_DATE = "98/04/03 07:10:15 GMT"
-GCN_FROM = "Greg Taylor at NRAO"
-GCN_BODY = """
-G.B. Taylor, D.A. Frail (NRAO), S.R. Kulkarni (Caltech), and
-the BeppoSAX GRB team report:
-
-We have observed the field containing the proposed x-ray counterpart
-1SAX J0702.6+3850 of GRB 980329 (IAUC 6854) with the VLA at 8.4 GHz
-on UT 1998 Mar 30.2, April 1.1, and April 2.1.  Observations on April
-1.1 detected a radio source VLA J0702+3850 within the 1 arcminute
-error circle of 1SAX J0702.6+3850.  The coordinates of
-VLA J0702+3850 are: ra = 07h02m38.02170s dec = 38d50'44.0170" (equinox
-J2000) with an uncertainty of 0.05 arcsec in each coordinate.  The
-size of this radio source is less than 0.25 arcsec.  The density of
-sources on the sky stronger than 250 microJy at this frequency is
-0.0145 arcmin**-2.
-
-The flux density measurements of VLA J0702+3850 are as follows:
-
-Date(UT)   8.4 GHz Flux Density
---------   ----------------------
-Mar 30.2   166 +/- 50 microJy
-Apr  1.1   248 +/- 16    "
-Apr  2.1    65 +/- 25    "
-
-where the uncertainty in the measurement reflects the 1 sigma rms
-noise in the image.  These measurements clearly demonstrate that
-the radio source is variable on timescales of less than 1 day.
-This rapid variability is similar to that observed in the
-radio afterglow from GRB 970508.  We propose VLA J0702+3850
-is the radio afterglow from GRB 980329.
-
-Additional radio observations are in progress.
-"""
-
-GCN_CIRCULAR = f"""\
-TITLE:   {GCN_TITLE}
-NUMBER:  {GCN_NUMBER}
-SUBJECT: {GCN_SUBJECT}
-DATE:    {GCN_DATE}
-FROM:    {GCN_FROM}
-
-{GCN_BODY}\
-"""
-
-
-def test_read_parse_gcn():
-    with patch("builtins.open", mock_open(read_data=GCN_CIRCULAR)) as mock_file:
+def test_read_parse_gcn(circular_text, circular_msg):
+    with patch("builtins.open", mock_open(read_data=circular_text)) as mock_file:
         gcn_file = "example.gcn3"
         gcn = publish.read_parse_gcn(gcn_file)
 
         # verify GCN was read in
-        assert open(gcn_file).read() == GCN_CIRCULAR
+        assert open(gcn_file).read() == circular_text
         mock_file.assert_called_with(gcn_file)
 
         # verify parsed GCN structure is correct
-        assert gcn.header["title"] == GCN_TITLE
-        assert gcn.header["number"] == GCN_NUMBER
-        assert gcn.header["subject"] == GCN_SUBJECT
-        assert gcn.header["date"] == GCN_DATE
-        assert gcn.header["from"] == GCN_FROM
+        assert gcn.header["title"] == circular_msg["header"]["title"]
+        assert gcn.header["number"] == circular_msg["header"]["number"]
+        assert gcn.header["subject"] == circular_msg["header"]["subject"]
+        assert gcn.header["date"] == circular_msg["header"]["date"]
+        assert gcn.header["from"] == circular_msg["header"]["from"]
 
-        assert gcn.body == GCN_BODY
+        assert gcn.body == circular_msg["body"]

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -70,10 +70,10 @@ def test_read_parse_gcn():
         mock_file.assert_called_with(gcn_file)
 
         # verify parsed GCN structure is correct
-        assert gcn["header"]["title"] == GCN_TITLE
-        assert gcn["header"]["number"] == GCN_NUMBER
-        assert gcn["header"]["subject"] == GCN_SUBJECT
-        assert gcn["header"]["date"] == GCN_DATE
-        assert gcn["header"]["from"] == GCN_FROM
+        assert gcn.header["title"] == GCN_TITLE
+        assert gcn.header["number"] == GCN_NUMBER
+        assert gcn.header["subject"] == GCN_SUBJECT
+        assert gcn.header["date"] == GCN_DATE
+        assert gcn.header["from"] == GCN_FROM
 
-        assert gcn["body"] == GCN_BODY
+        assert gcn.body == GCN_BODY


### PR DESCRIPTION
## Description

This PR implements #48, to define a python-based client API to read and write messages from a Kafka broker. The way it's done is to have a small wrapper around the genesis client, allowing us to implement different defaults and further down the line, control which messages are allowed without expecting the genesis client to do so.

In doing so, I have also implemented data classes for GCN Circulars and VOEvents to define the structure of messages, which are used within `scimma publish` for the circulars.

Additionally, there has been some restructuring in the test suite to avoid repeating code.

This can merged independently of #5, and the test suite restructure may help out there as well.

One example:
```
    from scimma.client import stream
    with stream.open("kafka://hostname:port/topic", "r", format="json") as s:
        for idx, msg in s:
             print(msg)

    with stream.open("kafka://hostname:port/topic", "w", format="json") as s:
        s.write({"my": "message"})
```

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
