### PR TITLE
Add VOEvent.from_xml()

### DIFF
--- a/scimma/client/models.py
+++ b/scimma/client/models.py
@@ -6,6 +6,8 @@ __description__ = "a module to define common message types"
 
 from dataclasses import asdict, dataclass, field
 
+import xmltodict
+
 
 @dataclass
 class VOEvent(object):
@@ -37,6 +39,22 @@ class VOEvent(object):
 
         """
         return asdict(self)
+
+    @classmethod
+    def from_xml(cls, xml_input):
+        """Create a new VOEvent from an XML-formatted VOEvent.
+
+        Args:
+            xml_input: a file object, string, or generator
+
+        Returns:
+            The VOEvent.
+
+        """
+        vo = xmltodict.parse(xml_input, attr_prefix="")
+
+        # enter root and remove XML-specific namespaces
+        return cls(**{k: v for k, v in vo["voe:VOEvent"].items() if ":" not in k})
 
 
 @dataclass

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,5 @@ exclude =
     build/,
     doc/
 per-file-ignores =
-	__init__.py:F401
+	__init__.py:F401,
+    tests/conftest.py:E501

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ with open(os.path.join(this_dir, 'README.md'), 'rb') as f:
 # requirements
 install_requires = [
     "adc >= 0.0.2",
-    "dataclasses ; python_version < '3.7'"
+    "dataclasses ; python_version < '3.7'",
+    "xmltodict >= 0.9.0"
 ]
 extras_require = {
     'dev': ['pytest', 'pytest-console-scripts', 'pytest-cov', 'flake8', 'flake8-black'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ __author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
 __description__ = "global configuration for pytest suite"
 
 
+import io
+
 import pytest
 
 
@@ -57,6 +59,112 @@ FROM:    {GCN_FROM}
 {GCN_BODY}\
 """
 
+VOEVENT_XML = """\
+<?xml version='1.0' encoding='UTF-8'?>
+<voe:VOEvent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:voe="http://www.ivoa.net/xml/VOEvent/v2.0" xsi:schemaLocation="http://www.ivoa.net/xml/VOEvent/v2.0 http://www.ivoa.net/xml/VOEvent/VOEvent-v2.0.xsd" version="2.0" role="observation" ivorn="ivo://gwnet/LVC#S200302c-1-Preliminary">
+  <Who>
+    <Date>2020-03-02T02:00:09</Date>
+    <Author>
+      <contactName>LIGO Scientific Collaboration and Virgo Collaboration</contactName>
+    </Author>
+  </Who>
+  <What>
+    <Param dataType="int" name="Packet_Type" value="150">
+      <Description>The Notice Type number is assigned/used within GCN, eg type=150 is an LVC_PRELIMINARY notice</Description>
+    </Param>
+    <Param dataType="int" name="internal" value="0">
+      <Description>Indicates whether this event should be distributed to LSC/Virgo members only</Description>
+    </Param>
+    <Param dataType="int" name="Pkt_Ser_Num" value="1">
+      <Description>A number that increments by 1 each time a new revision is issued for this event</Description>
+    </Param>
+    <Param dataType="string" name="GraceID" ucd="meta.id" value="S200302c">
+      <Description>Identifier in GraceDB</Description>
+    </Param>
+    <Param dataType="string" name="AlertType" ucd="meta.version" value="Preliminary">
+      <Description>VOEvent alert type</Description>
+    </Param>
+    <Param dataType="int" name="HardwareInj" ucd="meta.number" value="0">
+      <Description>Indicates that this event is a hardware injection if 1, no if 0</Description>
+    </Param>
+    <Param dataType="int" name="OpenAlert" ucd="meta.number" value="1">
+      <Description>Indicates that this event is an open alert if 1, no if 0</Description>
+    </Param>
+    <Param dataType="string" name="EventPage" ucd="meta.ref.url" value="https://gracedb.ligo.org/superevents/S200302c/view/">
+      <Description>Web page for evolving status of this GW candidate</Description>
+    </Param>
+    <Param dataType="string" name="Instruments" ucd="meta.code" value="H1,V1">
+      <Description>List of instruments used in analysis to identify this event</Description>
+    </Param>
+    <Param dataType="float" name="FAR" ucd="arith.rate;stat.falsealarm" unit="Hz" value="9.349090689402942e-09">
+      <Description>False alarm rate for GW candidates with this strength or greater</Description>
+    </Param>
+    <Param dataType="string" name="Group" ucd="meta.code" value="CBC">
+      <Description>Data analysis working group</Description>
+    </Param>
+    <Param dataType="string" name="Pipeline" ucd="meta.code" value="gstlal">
+      <Description>Low-latency data analysis pipeline</Description>
+    </Param>
+    <Param dataType="string" name="Search" ucd="meta.code" value="AllSky">
+      <Description>Specific low-latency search</Description>
+    </Param>
+    <Group name="GW_SKYMAP" type="GW_SKYMAP">
+      <Param dataType="string" name="skymap_fits" ucd="meta.ref.url" value="https://gracedb.ligo.org/api/superevents/S200302c/files/bayestar.fits.gz,0">
+        <Description>Sky Map FITS</Description>
+      </Param>
+    </Group>
+    <Group name="Classification" type="Classification">
+      <Param dataType="float" name="BNS" ucd="stat.probability" value="0.0">
+        <Description>Probability that the source is a binary neutron star merger (both objects lighter than 3 solar masses)</Description>
+      </Param>
+      <Param dataType="float" name="NSBH" ucd="stat.probability" value="0.0">
+        <Description>Probability that the source is a neutron star-black hole merger (primary heavier than 5 solar masses, secondary lighter than 3 solar masses)</Description>
+      </Param>
+      <Param dataType="float" name="BBH" ucd="stat.probability" value="0.8895532192171397">
+        <Description>Probability that the source is a binary black hole merger (both objects heavier than 5 solar masses)</Description>
+      </Param>
+      <Param dataType="float" name="MassGap" ucd="stat.probability" value="0.0">
+        <Description>Probability that the source has at least one object between 3 and 5 solar masses</Description>
+      </Param>
+      <Param dataType="float" name="Terrestrial" ucd="stat.probability" value="0.11044678078286028">
+        <Description>Probability that the source is terrestrial (i.e., a background noise fluctuation or a glitch)</Description>
+      </Param>
+      <Description>Source classification: binary neutron star (BNS), neutron star-black hole (NSBH), binary black hole (BBH), MassGap, or terrestrial (noise)</Description>
+    </Group>
+    <Group name="Properties" type="Properties">
+      <Param dataType="float" name="HasNS" ucd="stat.probability" value="0.0">
+        <Description>Probability that at least one object in the binary has a mass that is less than 3 solar masses</Description>
+      </Param>
+      <Param dataType="float" name="HasRemnant" ucd="stat.probability" value="0.0">
+        <Description>Probability that a nonzero mass was ejected outside the central remnant object</Description>
+      </Param>
+      <Description>Qualitative properties of the source, conditioned on the assumption that the signal is an astrophysical compact binary merger</Description>
+    </Group>
+  </What>
+  <WhereWhen>
+    <ObsDataLocation>
+      <ObservatoryLocation id="LIGO Virgo"/>
+      <ObservationLocation>
+        <AstroCoordSystem id="UTC-FK5-GEO"/>
+        <AstroCoords coord_system_id="UTC-FK5-GEO">
+          <Time unit="s">
+            <TimeInstant>
+              <ISOTime>2020-03-02T01:58:11.519119</ISOTime>
+            </TimeInstant>
+          </Time>
+        </AstroCoords>
+      </ObservationLocation>
+    </ObsDataLocation>
+  </WhereWhen>
+  <Description>Report of a candidate gravitational wave event</Description>
+  <How>
+    <Description>Candidate gravitational wave event identified by low-latency analysis</Description>
+    <Description>V1: Virgo 3 km gravitational wave detector</Description>
+    <Description>H1: LIGO Hanford 4 km gravitational wave detector</Description>
+  </How>
+</voe:VOEvent>\
+"""
+
 
 @pytest.fixture(scope="session")
 def circular_text():
@@ -75,3 +183,8 @@ def circular_msg():
         },
         "body": GCN_BODY,
     }
+
+
+@pytest.fixture(scope="session")
+def voevent_fileobj():
+    return io.BytesIO(VOEVENT_XML.encode())


### PR DESCRIPTION
## Description

Adds a new class method in the `VOEvent` model to read in XML formatted VOEvents, either from a file object, string, or generator.

Example:
```
from scimma.client import models

with open("voevent.xml", "rb") as f:
    voevent = models.VOEvent.from_xml(f)
```

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
