### PR TITLE
Publish GCN Notices from VOEvent-formatted files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SCiMMA Client
 Publish a GCN to Kafka:
 
 ```
-scimma publish -b kafka://hostname:port/gcn mygcn.gcn3
+scimma publish kafka://hostname:port/gcn mygcn.gcn3
 ```
 
 An example RFC 822 formatted GCN circular (`example.gcn3`) is provided in

--- a/doc/user/quickstart.rst
+++ b/doc/user/quickstart.rst
@@ -49,7 +49,7 @@ Publish a GCN
 
 .. code:: bash
 
-    scimma publish -b kafka://hostname:port/gcn mygcn.gcn3
+    scimma publish kafka://hostname:port/gcn mygcn.gcn3
 
 
 An example RFC 822 formatted GCN circular (:code:`example.gcn3`) is provided in :code:`tests/data`.

--- a/scimma/client/publish.py
+++ b/scimma/client/publish.py
@@ -43,9 +43,9 @@ def read_parse_gcn(gcn_file):
 
 def _add_parser_args(parser):
     parser.add_argument(
-        "uri",
-        metavar="URI",
-        help="Sets the URI (kafka://host[:port]/topic) to publish GCNs to.",
+        "url",
+        metavar="URL",
+        help="Sets the URL (kafka://host[:port]/topic) to publish GCNs to.",
     )
     parser.add_argument(
         "gcn", metavar="GCN", nargs="+", help="One or more GCNs to publish.",
@@ -82,7 +82,7 @@ def _main(args=None):
         config = None
 
     stream = Stream(format="json", config=config)
-    with stream.open(args.uri, "w") as s:
+    with stream.open(args.url, "w") as s:
         for gcn in args.gcn:
             extension = os.path.splitext(gcn)[1]
 

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,18 @@ install_requires = [
     "xmltodict >= 0.9.0"
 ]
 extras_require = {
-    'dev': ['pytest', 'pytest-console-scripts', 'pytest-cov', 'flake8', 'flake8-black'],
-    'docs': ['sphinx', 'sphinx_rtd_theme', 'sphinxcontrib-programoutput'],
+    'dev': [
+        'pytest >= 5.0, < 5.4',
+        'pytest-console-scripts',
+        'pytest-cov',
+        'flake8',
+        'flake8-black',
+    ],
+    'docs': [
+        'sphinx',
+        'sphinx_rtd_theme',
+        'sphinxcontrib-programoutput',
+    ],
 }
 
 setup(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,3 +188,8 @@ def circular_msg():
 @pytest.fixture(scope="session")
 def voevent_fileobj():
     return io.BytesIO(VOEVENT_XML.encode())
+
+
+@pytest.fixture(scope="session")
+def voevent_text():
+    return VOEVENT_XML

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,10 +22,11 @@ def test_cli_scimma(script_runner):
     assert ret.stderr == ""
 
 
-def test_cli_publish(script_runner, circular_text):
+def test_cli_publish(script_runner, circular_text, voevent_text):
     ret = script_runner.run("scimma", "publish", "--help")
     assert ret.success
 
+    # test GCN circular
     gcn_mock = mock_open(read_data=circular_text)
     with patch("scimma.client.publish.open", gcn_mock) as mock_file, patch(
         "scimma.client.io.Stream.open", mock_open()
@@ -33,12 +34,30 @@ def test_cli_publish(script_runner, circular_text):
 
         gcn_file = "example.gcn3"
         broker_url = "kafka://hostname:port/gcn"
-        ret = script_runner.run("scimma", "publish", "-b", broker_url, gcn_file)
+        ret = script_runner.run("scimma", "publish", broker_url, gcn_file)
+
+        # verify CLI output
+        assert ret.success
+        assert ret.stderr == ""
+
+        # verify circular was processed
+        mock_file.assert_called_with(gcn_file, "r")
+        mock_stream.assert_called_with(broker_url, "w")
+
+    # test GCN notice
+    gcn_mock = mock_open(read_data=voevent_text.encode())
+    with patch("scimma.client.publish.open", gcn_mock) as mock_file, patch(
+        "scimma.client.io.Stream.open", mock_open()
+    ) as mock_stream:
+
+        gcn_file = "voevent.xml"
+        broker_url = "kafka://hostname:port/gcn"
+        ret = script_runner.run("scimma", "publish", broker_url, gcn_file)
 
         # verify CLI output
         assert ret.success
         assert ret.stderr == ""
 
         # verify GCN was processed
-        mock_file.assert_called_with(gcn_file, "r")
+        mock_file.assert_called_with(gcn_file, "rb")
         mock_stream.assert_called_with(broker_url, "w")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,8 @@ __description__ = "a module that tests entry points"
 
 
 from unittest.mock import patch, mock_open
+import sys
+
 import pytest
 
 from scimma.client import __version__
@@ -22,7 +24,7 @@ def test_cli_scimma(script_runner):
     assert ret.stderr == ""
 
 
-def test_cli_publish(script_runner, circular_text, voevent_text):
+def test_cli_publish_circular(script_runner, circular_text):
     ret = script_runner.run("scimma", "publish", "--help")
     assert ret.success
 
@@ -44,6 +46,8 @@ def test_cli_publish(script_runner, circular_text, voevent_text):
         mock_file.assert_called_with(gcn_file, "r")
         mock_stream.assert_called_with(broker_url, "w")
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
+def test_cli_publish_notice(script_runner, voevent_text):
     # test GCN notice
     gcn_mock = mock_open(read_data=voevent_text.encode())
     with patch("scimma.client.publish.open", gcn_mock) as mock_file, patch(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
+__description__ = "a module that tests models"
+
+
+from scimma.client import models
+
+
+def test_voevent(voevent_fileobj):
+    voevent = models.VOEvent.from_xml(voevent_fileobj)
+
+    # check a few attributes
+    assert voevent.ivorn == "ivo://gwnet/LVC#S200302c-1-Preliminary"
+    assert voevent.role == "observation"
+    assert voevent.version == "2.0"
+
+    assert voevent.Who["Date"] == "2020-03-02T02:00:09"
+    assert voevent.Description == "Report of a candidate gravitational wave event"
+    assert (
+        voevent.WhereWhen["ObsDataLocation"]["ObservatoryLocation"]["id"]
+        == "LIGO Virgo"
+    )


### PR DESCRIPTION
## Description

This PR implements #43, to be able to publish GCN notices from VOEvent files in XML format. In doing this, I had put some thought into how the command line interface was going to look like as we allow more types of messages to be published (and subscribed from) without cluttering the API and hopefully making it a bit intuitive to use.

Here's what I came up with:

```
scimma publish kafka://hostname:port/notice example1.xml example2.xml
```

I thought a reasonable thing to do was to make the parsing based on the file extension until we have proper schema validation. VOEvents (which notices are formatted in commonly) reasonably expect to be in XML format and circulars stored on the NASA GCN website have the .gcn3 extension.

I also changed the broker URL to be a positional argument, since it's really required and I think it looks a little cleaner. I also expect once we have a canonical URL we can point to with well-defined topics, someone can drop most of the URL and it'll pick up defaults as needed. Something like:

```
scimma publish notice example1.xml example2.xml
```
which when entered, should fill in the default kafka://hostname:port combination expecting to publish to the "notice" topic.

I renamed a few things and edited some comments to reflect the broader nature of publish.py.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
