### PR TITLE
Fix usage of io.Stream.open to reflect changes in Genesis

### DIFF
--- a/scimma/client/subscribe.py
+++ b/scimma/client/subscribe.py
@@ -113,5 +113,5 @@ def _main(args=None):
 
     stream = Stream(format=gcn_format, config=config, start_at=start_offset)
     with stream.open(args.url, "r") as s:
-        for _, gcn_dict in s(timeout=timeout):
+        for gcn_dict in s(timeout=timeout):
             print_gcn(gcn_dict, json_dump)


### PR DESCRIPTION
## Description

An update to the Genesis streaming client removed message index from the return output of
a scimma-client Stream object. This was overlooked in the primary subscriber PR #55, which was developed using an older version of ADC/Genesis. This hotfix removes the reference to the now-absent index.

See related Genesis commit here:
https://github.com/astronomy-commons/genesis-client/commit/39f3458faf002d6a0511e4e0af9c61fb3c05c1c3

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
