### PR TITLE
io.Consumer: subscribe to topics in one call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint :
 	# stop the build if there are Python syntax errors or undefined names
 	flake8 hop tests setup.py --count --select=E9,F63,F7,F82 --show-source --statistics
 	# exit-zero treats all errors as warnings
-	flake8 hop tests setup.py --count --exit-zero --max-complexity=12 --max-line-length=100 --statistics
+	flake8 hop tests setup.py --count --exit-zero --max-complexity=15 --max-line-length=100 --statistics
 
 .PHONY: format
 format :

--- a/hop/io.py
+++ b/hop/io.py
@@ -285,8 +285,7 @@ class Consumer:
             group_id=group_id,
             **kwargs,
         ))
-        for t in topics:
-            self._consumer.subscribe(t)
+        self._consumer.subscribe(topics)
 
     def read(self, metadata=False, autocommit=True, **kwargs):
         """Read messages from a stream.


### PR DESCRIPTION

## Description

Addresses #70. Also update tests accordingly.

One aside, I bumped up the max-complexity in autopep8 again because it was not happy with the 'added complexity' of the MockConsumer in conftest.py. Seemed a bit obnoxious to me since the constructor signature wasn't changed.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [ ] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
