### PR TITLE
CI: modify build step to upgrade wheel/setuptools, add py3.9 in tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -19,6 +19,7 @@ jobs:
     - name: Build
       run: |
         python -m pip install --upgrade pip
+        pip install --upgrade wheel setuptools
         pip install .
     - name: Lint
       run: |


### PR DESCRIPTION
## Description

This PR updates the CI to test python3.9 as well. In addition, ensure setuptools/wheel are updated before installing anything else, which avoids conflicts between setuptools and setuptools_scm, etc.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
