### PR TITLE
Remove correct conflicting cred in auth.add_credential() when using --force

### DIFF
--- a/hop/auth.py
+++ b/hop/auth.py
@@ -430,7 +430,7 @@ def add_credential(args):
                 conflicting_cred_idx = idx
     if conflicting_cred_idx is not None:
         if args.force:
-            creds[idx] = new_cred
+            creds[conflicting_cred_idx] = new_cred
         else:
             logger.error("Credential already exists; overwrite with --force")
             return


### PR DESCRIPTION
## Description

When adding a new conflicting credential into the auth file and --force is specified, it was the case that it would remove the last credential rather than the conflicting credential. This PR fixes that issue and extends a test to verify the behavior is correct. 

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
