### PR TITLE
Add a test of keyboard interrupt handling

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,6 +204,20 @@ def test_cli_subscribe_logging(script_runner):
         assert "DEBUG" in ret.stderr
 
 
+def test_cli_interrupt(script_runner):
+    mock_consumer = MagicMock()
+    interrupt = MagicMock(side_effect=KeyboardInterrupt())
+    mock_consumer.__enter__ = interrupt
+    mock_consumer.__iter__ = interrupt
+    mock_consumer.__exit__ = interrupt
+    with patch("hop.io.Stream.open", MagicMock(return_value=mock_consumer)):
+        broker_url = "kafka://hostname:port/topic"
+        ret = script_runner.run("hop", "subscribe", broker_url, "--no-auth")
+        assert ret.success
+        assert "INFO" in ret.stderr
+        assert "received keyboard interrupt, closing" in ret.stderr
+
+
 def dummy_topic_info(topic, error=None):
     info = MagicMock()
     info.error = error


### PR DESCRIPTION
## Description

This just adds a test of the existing feature to get us back to complete line coverage. 

## Checklist

* ~[ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)~
* ~[ ] Add/update sphinx documentation with any relevant changes.~
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.