### PR TITLE
Accept but ignore `kafka://` prefixes on manually entered hostnames

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -534,31 +534,23 @@ def test_read_new_credential_interactive_invalid(tmpdir):
     assert err.value.args[0] == "Password may not be empty"
 
 
-def test_read_new_credential_hostname_variations(tmpdir):
+def test_hostname_validation():
     username = "foo"
     password = "bar"
     # good cases
     for hostname in ["example.com", "example.com:9092",
                      "kafka://example.com", "kafka://example.com:9092"]:
-        with patch("getpass.getpass", MagicMock(return_value=password)), \
-                patch("hop.auth.input",
-                      MagicMock(side_effect=[username, hostname])):
-            new_cred = auth.read_new_credential()
-            assert new_cred.username == username
-            assert new_cred.password == password
-            if "kafka://" in hostname:
-                assert new_cred.hostname == hostname[8:]
-            else:
-                assert new_cred.hostname == hostname
+        processed_hostname = auth._validate_hostname(hostname)
+        if "kafka://" in hostname:
+            assert processed_hostname == hostname[8:]
+        else:
+            assert processed_hostname == hostname
     # bad cases
     for hostname in ["http://example.com", "file:///usr/bin", "foo/bar",
                      "kafka://example.com/topic",
                      "kafka://example.com:9092/topic"]:
-        with patch("getpass.getpass", MagicMock(return_value=password)), \
-                patch("hop.auth.input",
-                      MagicMock(side_effect=[username, hostname])), \
-                pytest.raises(RuntimeError) as err:
-            new_cred = auth.read_new_credential()
+        with pytest.raises(RuntimeError) as err:
+            processed_hostname = auth._validate_hostname(hostname)
         assert "Unable to parse hostname" in err.value.args[0]
 
 


### PR DESCRIPTION
## Description

Addresses https://github.com/scimma/hop-client/issues/157 .
Since we are not actually asking for a URL, and URL parsing does surprising things when no scheme is present, this change instead tries to be minimally clever and just uses a regular expression which accepts a narrow set of (hopefully) definitely good inputs, and just complains to the user about anything it can't understand. 
It would be easy enough to accept (and discard) arbitrary URL schemes if we wanted to; for now this has not been done on the groups that anyone entering a non-`kafka:` scheme is likely to be on the wrong track entirely. 
There may also be room to improve the error message/help text. 

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.