### PR TITLE
Avoid encoding message headers to keep confluent-kafka happy.

### DIFF
--- a/hop/io.py
+++ b/hop/io.py
@@ -377,22 +377,6 @@ class Consumer:
         self.close()
 
 
-def _ensure_bytes_like(thing):
-    """Force an object which may be string-like to be bytes-like
-
-    Args:
-        thing: something which might be a string or might already be encoded as bytes.
-
-    Return:
-        Either the original input object or the encoding of that object as bytes.
-    """
-    try:  # check whether thing is bytes-like
-        memoryview(thing)
-        return thing  # keep as-is
-    except TypeError:
-        return thing.encode("utf-8")
-
-
 class Producer:
     """
     An event stream opened for writing to a topic.
@@ -432,7 +416,8 @@ class Producer:
             message: The message to write.
             headers: The set of headers requested to be sent with the message, either as a
                      mapping, or as a list of 2-tuples. In either the mapping or the list case,
-                     all header keys and values should be either string-like or bytes-like objects.
+                     all header keys must be strings and and values should be either string-like or
+                     bytes-like objects.
             delivery_callback: A callback which will be called when each message
                 is either delivered or permenantly fails to be delivered.
             test: Message should be marked as a test message by adding a header
@@ -470,7 +455,8 @@ class Producer:
             message: The message to pack and serialize.
             headers: The set of headers requested to be sent with the message, either as a
                      mapping, or as a list of 2-tuples. In either the mapping or the list case,
-                     all header keys and values should be either string-like or bytes-like objects.
+                     all header keys must be strings and and values should be either string-like or
+                     bytes-like objects.
             test: Message should be marked as a test message by adding a header
                   with key '_test'.
 
@@ -483,10 +469,8 @@ class Producer:
             headers = []
         elif isinstance(headers, Mapping):
             headers = list(headers.items())
-        # ensure all headers are encoded
-        headers = [(_ensure_bytes_like(k), _ensure_bytes_like(v)) for k, v in headers]
         if test:
-            headers.append(('_test', _ensure_bytes_like('true')))
+            headers.append(('_test', b"true"))
         try:
             payload = message.serialize()
         except AttributeError:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -166,7 +166,7 @@ def test_stream_write(circular_msg, circular_text, mock_broker, mock_producer):
     expected_msg = json.dumps(Blob(circular_msg).serialize()).encode("utf-8")
 
     headers = {"some header": "some value", "another header": b"other value"}
-    canonical_headers = [(b"some header", b"some value"), (b"another header", b"other value")]
+    canonical_headers = [("some header", "some value"), ("another header", b"other value")]
     test_headers = canonical_headers.copy()
     test_headers.append(('_test', b'true'))
     none_test_headers = []


### PR DESCRIPTION
## Description

As Ron discovered yesterday, confluent-kafka-python wants to be responsible for encoding the message header keys, and will also encode the values as well, so this change gets `hop.io.Producer` out of the business of doing that. 

## Checklist

* ~[ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)~
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.